### PR TITLE
Fixed failure to index nested 'objects'

### DIFF
--- a/src/main/java/com/englishtown/vertx/elasticsearch/impl/DefaultElasticSearchService.java
+++ b/src/main/java/com/englishtown/vertx/elasticsearch/impl/DefaultElasticSearchService.java
@@ -76,7 +76,7 @@ public class DefaultElasticSearchService implements ElasticSearchService {
     public void index(String index, String type, JsonObject source, IndexOptions options, Handler<AsyncResult<JsonObject>> resultHandler) {
 
         IndexRequestBuilder builder = client.prepareIndex(index, type)
-                .setSource(source.getMap());
+                .setSource(source.encode());
 
         if (options != null) {
             if (options.getId() != null) builder.setId(options.getId());


### PR DESCRIPTION
The .getMap method works fine for the current level, but internal JsonObject's get screwed up.
Getting the actual json string solves the problem... it is probably converted into that same format later on by the ES client.

Example that used to fail:
{"obj": { "a1": ["apple"] } }