### PR TITLE
Add support for executing search templates

### DIFF
--- a/src/main/asciidoc/cheatsheet/SearchOptions.adoc
+++ b/src/main/asciidoc/cheatsheet/SearchOptions.adoc
@@ -48,4 +48,10 @@
 |-
 |[[trackScores]]`trackScores`
 |`Boolean`
+|-
+|[[templateName]]`templateName`
+|`String`
+|-
+|[[templateType]]`templateType`
+|`String`
 |-|===

--- a/src/main/java/com/englishtown/vertx/elasticsearch/SearchOptions.java
+++ b/src/main/java/com/englishtown/vertx/elasticsearch/SearchOptions.java
@@ -4,6 +4,7 @@ import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.elasticsearch.action.search.SearchType;
+import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.sort.SortOrder;
 
 import java.util.ArrayList;
@@ -35,6 +36,9 @@ public class SearchOptions {
     private JsonObject aggregations;
     private List<SortOption> sorts = new ArrayList<>();
     private JsonObject extraSource;
+    private String templateName;
+    private ScriptService.ScriptType templateType;
+    private JsonObject templateParams;
 
     public static final String JSON_FIELD_TYPES = "types";
     public static final String JSON_FIELD_SEARCH_TYPE = "searchType";
@@ -56,6 +60,9 @@ public class SearchOptions {
     public static final String JSON_FIELD_AGGREGATIONS = "aggregations";
     public static final String JSON_FIELD_SORTS = "sorts";
     public static final String JSON_FIELD_EXTRA_SOURCE = "extraSource";
+    public static final String JSON_FIELD_TEMPLATE_NAME = "templateName";
+    public static final String JSON_FIELD_TEMPLATE_TYPE = "templateType";
+    public static final String JSON_FIELD_TEMPLATE_PARAMS = "templateParams";
 
     public SearchOptions() {
     }
@@ -81,6 +88,9 @@ public class SearchOptions {
         aggregations = other.getAggregations();
         sorts = other.getSorts();
         extraSource = other.getExtraSource();
+        templateName = other.getTemplateName();
+        templateType = other.getTemplateType();
+        templateParams = other.getTemplateParams();
     }
 
     public SearchOptions(JsonObject json) {
@@ -103,6 +113,17 @@ public class SearchOptions {
         trackScores = json.getBoolean(JSON_FIELD_TRACK_SCORES);
         aggregations = json.getJsonObject(JSON_FIELD_AGGREGATIONS);
         extraSource = json.getJsonObject(JSON_FIELD_EXTRA_SOURCE);
+        templateName = json.getString(JSON_FIELD_TEMPLATE_NAME);
+
+        if (json.containsKey(JSON_FIELD_TEMPLATE_TYPE)) {
+            for (ScriptService.ScriptType t : ScriptService.ScriptType.values()) {
+                if (t.name().equals(json.getString(JSON_FIELD_TEMPLATE_TYPE).toUpperCase())) {
+                    templateType = ScriptService.ScriptType.valueOf(json.getString(JSON_FIELD_TEMPLATE_TYPE).toUpperCase());
+                }
+            }
+        }
+
+        templateParams = json.getJsonObject(JSON_FIELD_TEMPLATE_PARAMS);
 
         String s = json.getString(JSON_FIELD_SEARCH_TYPE);
         if (s != null) searchType = SearchType.fromString(s);
@@ -296,6 +317,33 @@ public class SearchOptions {
         return this;
     }
 
+    public String getTemplateName() {
+        return templateName;
+    }
+
+    public SearchOptions setTemplateName(String templateName) {
+        this.templateName = templateName;
+        return this;
+    }
+
+    public ScriptService.ScriptType getTemplateType() {
+        return templateType;
+    }
+
+    public SearchOptions setTemplateType(ScriptService.ScriptType templateType) {
+        this.templateType = templateType;
+        return this;
+    }
+
+    public JsonObject getTemplateParams() {
+        return templateParams;
+    }
+
+    public SearchOptions setTemplateParams(JsonObject templateParams) {
+        this.templateParams = templateParams;
+        return this;
+    }
+
     public JsonObject toJson() {
 
         JsonObject json = new JsonObject();
@@ -319,6 +367,9 @@ public class SearchOptions {
         if (trackScores != null) json.put(JSON_FIELD_TRACK_SCORES, trackScores);
         if (aggregations != null) json.put(JSON_FIELD_AGGREGATIONS, aggregations);
         if (explain != null) json.put(JSON_FIELD_EXPLAIN, explain);
+        if (templateName != null) json.put(JSON_FIELD_TEMPLATE_NAME, templateName);
+        if (templateType != null) json.put(JSON_FIELD_TEMPLATE_TYPE, templateType);
+        if (templateParams != null) json.put(JSON_FIELD_TEMPLATE_PARAMS, templateParams);
 
         if (!sorts.isEmpty()) {
             JsonArray jsonSorts = new JsonArray();

--- a/src/main/java/com/englishtown/vertx/elasticsearch/impl/DefaultElasticSearchService.java
+++ b/src/main/java/com/englishtown/vertx/elasticsearch/impl/DefaultElasticSearchService.java
@@ -23,6 +23,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.script.ScriptService;
 
 import javax.inject.Inject;
 import java.io.IOException;
@@ -245,6 +246,9 @@ public class DefaultElasticSearchService implements ElasticSearchService {
                 options.getSorts().forEach(sort -> builder.addSort(sort.getField(), sort.getOrder()));
             }
             if (options.getExtraSource() != null) builder.setExtraSource(options.getExtraSource().encode());
+            if (options.getTemplateName() != null) builder.setTemplateName(options.getTemplateName());
+            if (options.getTemplateType() != null) builder.setTemplateType(options.getTemplateType());
+            if (options.getTemplateParams() != null) builder.setTemplateParams(options.getTemplateParams().getMap());
         }
 
         builder.execute(new ActionListener<SearchResponse>() {

--- a/src/test/java/com/englishtown/vertx/elasticsearch/SearchOptionsTest.java
+++ b/src/test/java/com/englishtown/vertx/elasticsearch/SearchOptionsTest.java
@@ -2,10 +2,12 @@ package com.englishtown.vertx.elasticsearch;
 
 import io.vertx.core.json.JsonObject;
 import org.elasticsearch.action.search.SearchType;
+import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.sort.SortOrder;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 /**
  * Unit tests for {@link SearchOptions}
@@ -43,7 +45,10 @@ public class SearchOptionsTest {
                 .setAggregations(new JsonObject().put("name", "name"))
                 .addSort("status", SortOrder.ASC)
                 .addSort("insert_date", SortOrder.ASC)
-                .setExtraSource(new JsonObject().put("extra", "1"));
+                .setExtraSource(new JsonObject().put("extra", "1"))
+                .setTemplateName("templateName")
+                .setTemplateType(ScriptService.ScriptType.INDEXED)
+                .setTemplateParams(new JsonObject().put("template_param", "sample_param"));
 
         json1 = options1.toJson();
 
@@ -57,6 +62,24 @@ public class SearchOptionsTest {
 
         assertEquals(json1.encode(), json2.encode());
 
+    }
+
+    @Test
+    public void testSetTemplateTypeFromJson() {
+
+        JsonObject json = new JsonObject();
+
+        json.put("templateType", "not-a-real-enum");
+        SearchOptions options = new SearchOptions(json);
+        assertNull(options.getTemplateType());
+
+        json.put("templateType", "file");
+        options = new SearchOptions(json);
+        assertEquals(options.getTemplateType(), ScriptService.ScriptType.FILE);
+
+        json.remove("templateType");
+        options = new SearchOptions(json);
+        assertNull(options.getTemplateType());
     }
 
 }


### PR DESCRIPTION
This pull request adds 3 properties to the `SearchOptions.java` data object that add support for doing searches based on search templates:

- templateName (String)
- templateType (String)
- templateParams (Map\<String, String\>)

It also adds these properties to the `SearchRequestBuilder` in `DefaultElasticSearchService.search()`.

I also added these three properties to the `SearchOptionsTest.java`