### PR TITLE
Fix indexing of deep objects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>vertx-elasticsearch-service</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1-SNAPSHOT</version>
 
     <parent>
         <groupId>com.englishtown.vertx</groupId>

--- a/src/main/java/com/englishtown/vertx/elasticsearch/impl/DefaultElasticSearchService.java
+++ b/src/main/java/com/englishtown/vertx/elasticsearch/impl/DefaultElasticSearchService.java
@@ -76,7 +76,7 @@ public class DefaultElasticSearchService implements ElasticSearchService {
     public void index(String index, String type, JsonObject source, IndexOptions options, Handler<AsyncResult<JsonObject>> resultHandler) {
 
         IndexRequestBuilder builder = client.prepareIndex(index, type)
-                .setSource(source.getMap());
+                .setSource(source.encode());
 
         if (options != null) {
             if (options.getId() != null) builder.setId(options.getId());


### PR DESCRIPTION
JsonObject.getMap returns the original map from inside JsonObject. Deep nested objects are contained there as JsonObject Objects which implements Iterable of Map.Entry. IndexRequestBuilder.setSource(Map) uses XContentBuilder to transform the objects it gets. For an Iterable it creates an array of the items, in thatcase their toString value. This basically destroys indexing of nested object with the module, becuase the become an array of "key=value" Strings.
    
This patch changes the "getMap" to "encode" in order to hand the actual json to Elasticsearch.
